### PR TITLE
Fix requests without `access_token` causing an error

### DIFF
--- a/classes/Micropublisher.php
+++ b/classes/Micropublisher.php
@@ -19,7 +19,7 @@ class Micropublisher
         // access token from request is either in header or in form parameter
         if (empty($accesstoken = kirby()->request()->header('Authorization'))) {
             $body = kirby()->request()->body()->toArray();
-            $accesstoken = 'Bearer ' . $body['access_token'] ?? null;
+            $accesstoken = 'Bearer ' . ($body['access_token'] ?? '');
         }
         if (strlen($accesstoken) < 10) {
             return new Response('{"error":"unauthorized","error_description":"No access token was provided in the request"}', 'application/json', 401);


### PR DESCRIPTION
Your first fix did not work, I think PHP interpreted it as `('Bearer ' . $body['access_token']) ?? null`, so the `??` operator did not kick in where it was supposed to.