### PR TITLE
fix: provide correct micropub endpoint on multilang sites

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -1,15 +1,15 @@
 <?php
 
-function micropublisherEndpoints() {
+function micropublisherEndpoints()
+{
+    // setting this option to empty disables output of the default indieauth endpoint (f.ex. when using selfauth)
+    if (option('sgkirby.micropublisher.auth.authorization-endpoint' !== '')) {
+        $auth_endpoint = '<link rel="authorization_endpoint" href="' . option('sgkirby.micropublisher.auth.authorization-endpoint', 'https://indieauth.com/auth') . '" />';
+    } else {
+        $auth_endpoint = '';
+    }
 
-	// setting this option to empty disables output of the default indieauth endpoint (f.ex. when using selfauth)
-	if ( option( 'sgkirby.micropublisher.auth.authorization-endpoint' !== '' ) )
-		$auth_endpoint = '<link rel="authorization_endpoint" href="' . option( 'sgkirby.micropublisher.auth.authorization-endpoint', 'https://indieauth.com/auth' ) . '" />';
-	else
-		$auth_endpoint = '';
-
-	echo $auth_endpoint
-		. '<link rel="token_endpoint" href="' . option( 'sgkirby.micropublisher.auth.token-endpoint', 'https://tokens.indieauth.com/token' ) . '" />'
-		. '<link rel="micropub" href="' . site()->url() . '/' . option( 'sgkirby.micropublisher.endpoint', 'micropub' ) . '" />';
-
+    echo $auth_endpoint
+        . '<link rel="token_endpoint" href="' . option('sgkirby.micropublisher.auth.token-endpoint', 'https://tokens.indieauth.com/token') . '" />'
+        . '<link rel="micropub" href="' . site()->url('/') . '/' . option('sgkirby.micropublisher.endpoint', 'micropub') . '" />';
 }


### PR DESCRIPTION
Sorry for the reformatting, I just saw it and dind't want to reconfigure my IDE. I just added a '/' to the site->url() this will prevent adding a language-code to the micropub endpoint url on multilang sites (which won't work)

`site()->url('/')` 